### PR TITLE
Always detect a Ruby App

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,9 +1,4 @@
 #!/bin/sh
 
-if [ -f "$1/Gemfile" ]; then
-  echo "Ruby"
-  exit 0
-else
-  echo "no"
-  exit 1
-fi
+echo "Ruby"
+exit 0


### PR DESCRIPTION
This is a custom Ruby builpack, so it will always be a Ruby app that we
are building -- we do not have to check for the existence of a Gemfile.

Removing the check for a Gemfile at the project root also furthers the
goal of this particular project, which is to allow the Rails app (and
thus the Gemfile) in places other than the root directory.
